### PR TITLE
Common allocation callbacks

### DIFF
--- a/include/dr_libs/CMakeLists.txt
+++ b/include/dr_libs/CMakeLists.txt
@@ -1,4 +1,5 @@
 target_sources(${project_name} PRIVATE
+"${CMAKE_CURRENT_SOURCE_DIR}/dr_common.h"
 "${CMAKE_CURRENT_SOURCE_DIR}/dr_flac.h"
 "${CMAKE_CURRENT_SOURCE_DIR}/dr_mp3.h"
 "${CMAKE_CURRENT_SOURCE_DIR}/dr_wav.h"

--- a/include/dr_libs/dr_common.h
+++ b/include/dr_libs/dr_common.h
@@ -1,0 +1,13 @@
+#ifndef dr_common_h
+#define dr_common_h
+
+#include <stddef.h> /* For size_t. */
+
+typedef struct {
+  void* pUserData;
+  void* (*onMalloc)(size_t sz, void* pUserData);
+  void* (*onRealloc)(void* p, size_t sz, void* pUserData);
+  void (*onFree)(void* p, void* pUserData);
+} drlibs_allocation_callbacks;
+
+#endif

--- a/include/dr_libs/dr_flac.h
+++ b/include/dr_libs/dr_flac.h
@@ -151,6 +151,7 @@ extern "C" {
   DRFLAC_XSTRINGIFY(DRFLAC_VERSION_MAJOR)                                                          \
   "." DRFLAC_XSTRINGIFY(DRFLAC_VERSION_MINOR) "." DRFLAC_XSTRINGIFY(DRFLAC_VERSION_REVISION)
 
+#include <dr_libs/dr_common.h>
 #include <stddef.h> /* For size_t. */
 
 /* Sized types. */
@@ -476,13 +477,6 @@ tokens.
 */
 typedef void (*drflac_meta_proc)(void* pUserData, drflac_metadata* pMetadata);
 
-typedef struct {
-  void* pUserData;
-  void* (*onMalloc)(size_t sz, void* pUserData);
-  void* (*onRealloc)(void* p, size_t sz, void* pUserData);
-  void (*onFree)(void* p, void* pUserData);
-} drflac_allocation_callbacks;
-
 /* Structure for internal use. Only used for decoders opened with
  * drflac_open_memory. */
 typedef struct {
@@ -620,7 +614,7 @@ typedef struct {
   void* pUserDataMD;
 
   /* Memory allocation callbacks. */
-  drflac_allocation_callbacks allocationCallbacks;
+  drlibs_allocation_callbacks allocationCallbacks;
 
   /* The sample rate. Will be set to something like 44100. */
   drflac_uint32 sampleRate;
@@ -750,7 +744,7 @@ drflac_open_with_metadata()
 drflac_close()
 */
 DRFLAC_API drflac* drflac_open(drflac_read_proc onRead, drflac_seek_proc onSeek, void* pUserData,
-                               const drflac_allocation_callbacks* pAllocationCallbacks);
+                               const drlibs_allocation_callbacks* pAllocationCallbacks);
 
 /*
 Opens a FLAC stream with relaxed validation of the header block.
@@ -800,7 +794,7 @@ Use `drflac_open_with_metadata_relaxed()` if you need access to metadata.
 */
 DRFLAC_API drflac* drflac_open_relaxed(drflac_read_proc onRead, drflac_seek_proc onSeek,
                                        drflac_container container, void* pUserData,
-                                       const drflac_allocation_callbacks* pAllocationCallbacks);
+                                       const drlibs_allocation_callbacks* pAllocationCallbacks);
 
 /*
 Opens a FLAC decoder and notifies the caller of the metadata chunks (album art,
@@ -872,7 +866,7 @@ drflac_close()
 */
 DRFLAC_API drflac*
 drflac_open_with_metadata(drflac_read_proc onRead, drflac_seek_proc onSeek, drflac_meta_proc onMeta,
-                          void* pUserData, const drflac_allocation_callbacks* pAllocationCallbacks);
+                          void* pUserData, const drlibs_allocation_callbacks* pAllocationCallbacks);
 
 /*
 The same as drflac_open_with_metadata(), except attempts to open the stream even
@@ -887,7 +881,7 @@ DRFLAC_API drflac*
 drflac_open_with_metadata_relaxed(drflac_read_proc onRead, drflac_seek_proc onSeek,
                                   drflac_meta_proc onMeta, drflac_container container,
                                   void* pUserData,
-                                  const drflac_allocation_callbacks* pAllocationCallbacks);
+                                  const drlibs_allocation_callbacks* pAllocationCallbacks);
 
 /*
 Closes the given FLAC decoder.
@@ -1074,9 +1068,9 @@ drflac_open()
 drflac_close()
 */
 DRFLAC_API drflac* drflac_open_file(const char* pFileName,
-                                    const drflac_allocation_callbacks* pAllocationCallbacks);
+                                    const drlibs_allocation_callbacks* pAllocationCallbacks);
 DRFLAC_API drflac* drflac_open_file_w(const wchar_t* pFileName,
-                                      const drflac_allocation_callbacks* pAllocationCallbacks);
+                                      const drlibs_allocation_callbacks* pAllocationCallbacks);
 
 /*
 Opens a FLAC decoder from the file at the given path and notifies the caller of
@@ -1116,10 +1110,10 @@ drflac_close()
 */
 DRFLAC_API drflac*
 drflac_open_file_with_metadata(const char* pFileName, drflac_meta_proc onMeta, void* pUserData,
-                               const drflac_allocation_callbacks* pAllocationCallbacks);
+                               const drlibs_allocation_callbacks* pAllocationCallbacks);
 DRFLAC_API drflac*
 drflac_open_file_with_metadata_w(const wchar_t* pFileName, drflac_meta_proc onMeta, void* pUserData,
-                                 const drflac_allocation_callbacks* pAllocationCallbacks);
+                                 const drlibs_allocation_callbacks* pAllocationCallbacks);
 #endif
 
 /*
@@ -1155,7 +1149,7 @@ drflac_open()
 drflac_close()
 */
 DRFLAC_API drflac* drflac_open_memory(const void* pData, size_t dataSize,
-                                      const drflac_allocation_callbacks* pAllocationCallbacks);
+                                      const drlibs_allocation_callbacks* pAllocationCallbacks);
 
 /*
 Opens a FLAC decoder from a pre-allocated block of memory and notifies the
@@ -1195,7 +1189,7 @@ drflac_close()
 DRFLAC_API drflac*
 drflac_open_memory_with_metadata(const void* pData, size_t dataSize, drflac_meta_proc onMeta,
                                  void* pUserData,
-                                 const drflac_allocation_callbacks* pAllocationCallbacks);
+                                 const drlibs_allocation_callbacks* pAllocationCallbacks);
 
 /* High Level APIs */
 
@@ -1219,7 +1213,7 @@ DRFLAC_API drflac_int32*
 drflac_open_and_read_pcm_frames_s32(drflac_read_proc onRead, drflac_seek_proc onSeek,
                                     void* pUserData, unsigned int* channels,
                                     unsigned int* sampleRate, drflac_uint64* totalPCMFrameCount,
-                                    const drflac_allocation_callbacks* pAllocationCallbacks);
+                                    const drlibs_allocation_callbacks* pAllocationCallbacks);
 
 /* Same as drflac_open_and_read_pcm_frames_s32(), except returns signed 16-bit
  * integer samples. */
@@ -1227,7 +1221,7 @@ DRFLAC_API drflac_int16*
 drflac_open_and_read_pcm_frames_s16(drflac_read_proc onRead, drflac_seek_proc onSeek,
                                     void* pUserData, unsigned int* channels,
                                     unsigned int* sampleRate, drflac_uint64* totalPCMFrameCount,
-                                    const drflac_allocation_callbacks* pAllocationCallbacks);
+                                    const drlibs_allocation_callbacks* pAllocationCallbacks);
 
 /* Same as drflac_open_and_read_pcm_frames_s32(), except returns 32-bit
  * floating-point samples. */
@@ -1235,45 +1229,45 @@ DRFLAC_API float*
 drflac_open_and_read_pcm_frames_f32(drflac_read_proc onRead, drflac_seek_proc onSeek,
                                     void* pUserData, unsigned int* channels,
                                     unsigned int* sampleRate, drflac_uint64* totalPCMFrameCount,
-                                    const drflac_allocation_callbacks* pAllocationCallbacks);
+                                    const drlibs_allocation_callbacks* pAllocationCallbacks);
 
 #ifndef DR_FLAC_NO_STDIO
 /* Same as drflac_open_and_read_pcm_frames_s32() except opens the decoder from a
  * file. */
 DRFLAC_API drflac_int32* drflac_open_file_and_read_pcm_frames_s32(
     const char* filename, unsigned int* channels, unsigned int* sampleRate,
-    drflac_uint64* totalPCMFrameCount, const drflac_allocation_callbacks* pAllocationCallbacks);
+    drflac_uint64* totalPCMFrameCount, const drlibs_allocation_callbacks* pAllocationCallbacks);
 
 /* Same as drflac_open_file_and_read_pcm_frames_s32(), except returns signed
  * 16-bit integer samples. */
 DRFLAC_API drflac_int16* drflac_open_file_and_read_pcm_frames_s16(
     const char* filename, unsigned int* channels, unsigned int* sampleRate,
-    drflac_uint64* totalPCMFrameCount, const drflac_allocation_callbacks* pAllocationCallbacks);
+    drflac_uint64* totalPCMFrameCount, const drlibs_allocation_callbacks* pAllocationCallbacks);
 
 /* Same as drflac_open_file_and_read_pcm_frames_s32(), except returns 32-bit
  * floating-point samples. */
 DRFLAC_API float* drflac_open_file_and_read_pcm_frames_f32(
     const char* filename, unsigned int* channels, unsigned int* sampleRate,
-    drflac_uint64* totalPCMFrameCount, const drflac_allocation_callbacks* pAllocationCallbacks);
+    drflac_uint64* totalPCMFrameCount, const drlibs_allocation_callbacks* pAllocationCallbacks);
 #endif
 
 /* Same as drflac_open_and_read_pcm_frames_s32() except opens the decoder from a
  * block of memory. */
 DRFLAC_API drflac_int32* drflac_open_memory_and_read_pcm_frames_s32(
     const void* data, size_t dataSize, unsigned int* channels, unsigned int* sampleRate,
-    drflac_uint64* totalPCMFrameCount, const drflac_allocation_callbacks* pAllocationCallbacks);
+    drflac_uint64* totalPCMFrameCount, const drlibs_allocation_callbacks* pAllocationCallbacks);
 
 /* Same as drflac_open_memory_and_read_pcm_frames_s32(), except returns signed
  * 16-bit integer samples. */
 DRFLAC_API drflac_int16* drflac_open_memory_and_read_pcm_frames_s16(
     const void* data, size_t dataSize, unsigned int* channels, unsigned int* sampleRate,
-    drflac_uint64* totalPCMFrameCount, const drflac_allocation_callbacks* pAllocationCallbacks);
+    drflac_uint64* totalPCMFrameCount, const drlibs_allocation_callbacks* pAllocationCallbacks);
 
 /* Same as drflac_open_memory_and_read_pcm_frames_s32(), except returns 32-bit
  * floating-point samples. */
 DRFLAC_API float* drflac_open_memory_and_read_pcm_frames_f32(
     const void* data, size_t dataSize, unsigned int* channels, unsigned int* sampleRate,
-    drflac_uint64* totalPCMFrameCount, const drflac_allocation_callbacks* pAllocationCallbacks);
+    drflac_uint64* totalPCMFrameCount, const drlibs_allocation_callbacks* pAllocationCallbacks);
 
 /*
 Frees memory that was allocated internally by dr_flac.
@@ -1282,7 +1276,7 @@ Set pAllocationCallbacks to the same object that was passed to
 drflac_open_*_and_read_pcm_frames_*(). If you originally passed in NULL, pass in
 NULL for this.
 */
-DRFLAC_API void drflac_free(void* p, const drflac_allocation_callbacks* pAllocationCallbacks);
+DRFLAC_API void drflac_free(void* p, const drlibs_allocation_callbacks* pAllocationCallbacks);
 
 /* Structure representing an iterator for vorbis comments in a VORBIS_COMMENT
  * metadata block. */

--- a/include/dr_libs/dr_mp3.h
+++ b/include/dr_libs/dr_mp3.h
@@ -28,6 +28,7 @@ extern "C" {
   DRMP3_XSTRINGIFY(DRMP3_VERSION_MAJOR)                                                            \
   "." DRMP3_XSTRINGIFY(DRMP3_VERSION_MINOR) "." DRMP3_XSTRINGIFY(DRMP3_VERSION_REVISION)
 
+#include <dr_libs/dr_common.h>
 #include <stdbool.h> /* For true and false. */
 #include <stddef.h>  /* For size_t. */
 #include <stdint.h>  /* For sized types. */
@@ -220,13 +221,6 @@ drmp3_seek_origin_current.
 typedef bool (*drmp3_seek_proc)(void* pUserData, int offset, drmp3_seek_origin origin);
 
 typedef struct {
-  void* pUserData;
-  void* (*onMalloc)(size_t sz, void* pUserData);
-  void* (*onRealloc)(void* p, size_t sz, void* pUserData);
-  void (*onFree)(void* p, void* pUserData);
-} drmp3_allocation_callbacks;
-
-typedef struct {
   uint32_t channels;
   uint32_t sampleRate;
 } drmp3_config;
@@ -239,7 +233,7 @@ typedef struct {
   drmp3_read_proc onRead;
   drmp3_seek_proc onSeek;
   void* pUserData;
-  drmp3_allocation_callbacks allocationCallbacks;
+  drlibs_allocation_callbacks allocationCallbacks;
   uint32_t mp3FrameChannels;   /* The number of channels in the currently
                                       loaded MP3 frame. Internal use only. */
   uint32_t mp3FrameSampleRate; /* The sample rate of the currently loaded
@@ -286,7 +280,7 @@ Close the loader with drmp3_uninit().
 See also: drmp3_init_file(), drmp3_init_memory(), drmp3_uninit()
 */
 DRMP3_API drmp3* drmp3_init(drmp3_read_proc onRead, drmp3_seek_proc onSeek, void* pUserData,
-                            const drmp3_allocation_callbacks* pAllocationCallbacks);
+                            const drlibs_allocation_callbacks* pAllocationCallbacks);
 
 /*
 Initializes an MP3 decoder from a block of memory.
@@ -297,7 +291,7 @@ the buffer remains valid for the lifetime of the drmp3 object.
 The buffer should contain the contents of the entire MP3 file.
 */
 DRMP3_API drmp3* drmp3_init_memory(const void* pData, size_t dataSize,
-                                   const drmp3_allocation_callbacks* pAllocationCallbacks);
+                                   const drlibs_allocation_callbacks* pAllocationCallbacks);
 
 #ifndef DR_MP3_NO_STDIO
 /*
@@ -308,9 +302,9 @@ mind if you're caching drmp3 objects because the operating system may restrict
 the number of file handles an application can have open at any given time.
 */
 DRMP3_API drmp3* drmp3_init_file(const char* pFilePath,
-                                 const drmp3_allocation_callbacks* pAllocationCallbacks);
+                                 const drlibs_allocation_callbacks* pAllocationCallbacks);
 DRMP3_API drmp3* drmp3_init_file_w(const wchar_t* pFilePath,
-                                   const drmp3_allocation_callbacks* pAllocationCallbacks);
+                                   const drlibs_allocation_callbacks* pAllocationCallbacks);
 #endif
 
 /*
@@ -402,41 +396,41 @@ Free the returned pointer with drmp3_free().
 DRMP3_API float*
 drmp3_open_and_read_pcm_frames_f32(drmp3_read_proc onRead, drmp3_seek_proc onSeek, void* pUserData,
                                    drmp3_config* pConfig, uint64_t* pTotalFrameCount,
-                                   const drmp3_allocation_callbacks* pAllocationCallbacks);
+                                   const drlibs_allocation_callbacks* pAllocationCallbacks);
 DRMP3_API int16_t*
 drmp3_open_and_read_pcm_frames_s16(drmp3_read_proc onRead, drmp3_seek_proc onSeek, void* pUserData,
                                    drmp3_config* pConfig, uint64_t* pTotalFrameCount,
-                                   const drmp3_allocation_callbacks* pAllocationCallbacks);
+                                   const drlibs_allocation_callbacks* pAllocationCallbacks);
 
 DRMP3_API float*
 drmp3_open_memory_and_read_pcm_frames_f32(const void* pData, size_t dataSize, drmp3_config* pConfig,
                                           uint64_t* pTotalFrameCount,
-                                          const drmp3_allocation_callbacks* pAllocationCallbacks);
+                                          const drlibs_allocation_callbacks* pAllocationCallbacks);
 DRMP3_API int16_t*
 drmp3_open_memory_and_read_pcm_frames_s16(const void* pData, size_t dataSize, drmp3_config* pConfig,
                                           uint64_t* pTotalFrameCount,
-                                          const drmp3_allocation_callbacks* pAllocationCallbacks);
+                                          const drlibs_allocation_callbacks* pAllocationCallbacks);
 
 #ifndef DR_MP3_NO_STDIO
 DRMP3_API float*
 drmp3_open_file_and_read_pcm_frames_f32(const char* filePath, drmp3_config* pConfig,
                                         uint64_t* pTotalFrameCount,
-                                        const drmp3_allocation_callbacks* pAllocationCallbacks);
+                                        const drlibs_allocation_callbacks* pAllocationCallbacks);
 DRMP3_API int16_t*
 drmp3_open_file_and_read_pcm_frames_s16(const char* filePath, drmp3_config* pConfig,
                                         uint64_t* pTotalFrameCount,
-                                        const drmp3_allocation_callbacks* pAllocationCallbacks);
+                                        const drlibs_allocation_callbacks* pAllocationCallbacks);
 #endif
 
 /*
 Allocates a block of memory on the heap.
 */
-DRMP3_API void* drmp3_malloc(size_t sz, const drmp3_allocation_callbacks* pAllocationCallbacks);
+DRMP3_API void* drmp3_malloc(size_t sz, const drlibs_allocation_callbacks* pAllocationCallbacks);
 
 /*
 Frees any memory that was allocated by a public drmp3 API.
 */
-DRMP3_API void drmp3_free(void* p, const drmp3_allocation_callbacks* pAllocationCallbacks);
+DRMP3_API void drmp3_free(void* p, const drlibs_allocation_callbacks* pAllocationCallbacks);
 
 #ifdef __cplusplus
 }

--- a/include/dr_libs/dr_wav.h
+++ b/include/dr_libs/dr_wav.h
@@ -28,6 +28,7 @@ extern "C" {
   DRWAV_XSTRINGIFY(DRWAV_VERSION_MAJOR)                                                            \
   "." DRWAV_XSTRINGIFY(DRWAV_VERSION_MINOR) "." DRWAV_XSTRINGIFY(DRWAV_VERSION_REVISION)
 
+#include <dr_libs/dr_common.h>
 #include <stdbool.h> /* For true and false. */
 #include <stddef.h>  /* For size_t. */
 #include <stdint.h>  /* For sized types. */
@@ -282,13 +283,6 @@ typedef uint64_t (*drwav_chunk_proc)(void* pChunkUserData, drwav_read_proc onRea
                                      drwav_seek_proc onSeek, void* pReadSeekUserData,
                                      const drwav_chunk_header* pChunkHeader,
                                      drwav_container container, const drwav_fmt* pFMT);
-
-typedef struct {
-  void* pUserData;
-  void* (*onMalloc)(size_t sz, void* pUserData);
-  void* (*onRealloc)(void* p, size_t sz, void* pUserData);
-  void (*onFree)(void* p, void* pUserData);
-} drwav_allocation_callbacks;
 
 /* Structure for internal use. Only used for loaders opened with
  * drwav_init_memory(). */
@@ -716,7 +710,7 @@ typedef struct {
   void* pUserData;
 
   /* Allocation callbacks. */
-  drwav_allocation_callbacks allocationCallbacks;
+  drlibs_allocation_callbacks allocationCallbacks;
 
   /* Whether or not the WAV file is formatted as a standard RIFF file or W64. */
   drwav_container container;
@@ -840,14 +834,14 @@ the FMT chunk can be read from pWav->fmt after the function returns.
 See also: drwav_init_file(), drwav_init_memory(), drwav_uninit()
 */
 DRWAV_API drwav* drwav_init(drwav_read_proc onRead, drwav_seek_proc onSeek, void* pUserData,
-                            const drwav_allocation_callbacks* pAllocationCallbacks);
+                            const drlibs_allocation_callbacks* pAllocationCallbacks);
 DRWAV_API drwav* drwav_init_ex(drwav_read_proc onRead, drwav_seek_proc onSeek,
                                drwav_chunk_proc onChunk, void* pReadSeekUserData,
                                void* pChunkUserData, uint32_t flags,
-                               const drwav_allocation_callbacks* pAllocationCallbacks);
+                               const drlibs_allocation_callbacks* pAllocationCallbacks);
 DRWAV_API drwav* drwav_init_with_metadata(drwav_read_proc onRead, drwav_seek_proc onSeek,
                                           void* pUserData, uint32_t flags,
-                                          const drwav_allocation_callbacks* pAllocationCallbacks);
+                                          const drlibs_allocation_callbacks* pAllocationCallbacks);
 
 /*
 Initializes a pre-allocated drwav object for writing.
@@ -877,18 +871,18 @@ See also: drwav_init_file_write(), drwav_init_memory_write(), drwav_uninit()
 */
 DRWAV_API drwav* drwav_init_write(const drwav_data_format* pFormat, drwav_write_proc onWrite,
                                   drwav_seek_proc onSeek, void* pUserData,
-                                  const drwav_allocation_callbacks* pAllocationCallbacks);
+                                  const drlibs_allocation_callbacks* pAllocationCallbacks);
 DRWAV_API drwav*
 drwav_init_write_sequential(const drwav_data_format* pFormat, uint64_t totalSampleCount,
                             drwav_write_proc onWrite, void* pUserData,
-                            const drwav_allocation_callbacks* pAllocationCallbacks);
+                            const drlibs_allocation_callbacks* pAllocationCallbacks);
 DRWAV_API drwav* drwav_init_write_sequential_pcm_frames(
     const drwav_data_format* pFormat, uint64_t totalPCMFrameCount, drwav_write_proc onWrite,
-    void* pUserData, const drwav_allocation_callbacks* pAllocationCallbacks);
+    void* pUserData, const drlibs_allocation_callbacks* pAllocationCallbacks);
 DRWAV_API drwav*
 drwav_init_write_with_metadata(const drwav_data_format* pFormat, drwav_write_proc onWrite,
                                drwav_seek_proc onSeek, void* pUserData,
-                               const drwav_allocation_callbacks* pAllocationCallbacks,
+                               const drlibs_allocation_callbacks* pAllocationCallbacks,
                                drwav_metadata* pMetadata, uint32_t metadataCount);
 
 /*
@@ -1156,21 +1150,21 @@ mind if you're caching drwav objects because the operating system may restrict
 the number of file handles an application can have open at any given time.
 */
 DRWAV_API drwav* drwav_init_file(const char* filename,
-                                 const drwav_allocation_callbacks* pAllocationCallbacks);
+                                 const drlibs_allocation_callbacks* pAllocationCallbacks);
 DRWAV_API drwav* drwav_init_file_ex(const char* filename, drwav_chunk_proc onChunk,
                                     void* pChunkUserData, uint32_t flags,
-                                    const drwav_allocation_callbacks* pAllocationCallbacks);
+                                    const drlibs_allocation_callbacks* pAllocationCallbacks);
 DRWAV_API drwav* drwav_init_file_w(const wchar_t* filename,
-                                   const drwav_allocation_callbacks* pAllocationCallbacks);
+                                   const drlibs_allocation_callbacks* pAllocationCallbacks);
 DRWAV_API drwav* drwav_init_file_ex_w(const wchar_t* filename, drwav_chunk_proc onChunk,
                                       void* pChunkUserData, uint32_t flags,
-                                      const drwav_allocation_callbacks* pAllocationCallbacks);
+                                      const drlibs_allocation_callbacks* pAllocationCallbacks);
 DRWAV_API drwav*
 drwav_init_file_with_metadata(const char* filename, uint32_t flags,
-                              const drwav_allocation_callbacks* pAllocationCallbacks);
+                              const drlibs_allocation_callbacks* pAllocationCallbacks);
 DRWAV_API drwav*
 drwav_init_file_with_metadata_w(const wchar_t* filename, uint32_t flags,
-                                const drwav_allocation_callbacks* pAllocationCallbacks);
+                                const drlibs_allocation_callbacks* pAllocationCallbacks);
 
 /*
 Helper for initializing a wave file for writing using stdio.
@@ -1180,24 +1174,23 @@ mind if you're caching drwav objects because the operating system may restrict
 the number of file handles an application can have open at any given time.
 */
 DRWAV_API drwav* drwav_init_file_write(const char* filename, const drwav_data_format* pFormat,
-                                       const drwav_allocation_callbacks* pAllocationCallbacks);
+                                       const drlibs_allocation_callbacks* pAllocationCallbacks);
 DRWAV_API drwav*
 drwav_init_file_write_sequential(const char* filename, const drwav_data_format* pFormat,
                                  uint64_t totalSampleCount,
-                                 const drwav_allocation_callbacks* pAllocationCallbacks);
-DRWAV_API drwav*
-drwav_init_file_write_sequential_pcm_frames(const char* filename, const drwav_data_format* pFormat,
-                                            uint64_t totalPCMFrameCount,
-                                            const drwav_allocation_callbacks* pAllocationCallbacks);
+                                 const drlibs_allocation_callbacks* pAllocationCallbacks);
+DRWAV_API drwav* drwav_init_file_write_sequential_pcm_frames(
+    const char* filename, const drwav_data_format* pFormat, uint64_t totalPCMFrameCount,
+    const drlibs_allocation_callbacks* pAllocationCallbacks);
 DRWAV_API drwav* drwav_init_file_write_w(const wchar_t* filename, const drwav_data_format* pFormat,
-                                         const drwav_allocation_callbacks* pAllocationCallbacks);
+                                         const drlibs_allocation_callbacks* pAllocationCallbacks);
 DRWAV_API drwav*
 drwav_init_file_write_sequential_w(const wchar_t* filename, const drwav_data_format* pFormat,
                                    uint64_t totalSampleCount,
-                                   const drwav_allocation_callbacks* pAllocationCallbacks);
+                                   const drlibs_allocation_callbacks* pAllocationCallbacks);
 DRWAV_API drwav* drwav_init_file_write_sequential_pcm_frames_w(
     const wchar_t* filename, const drwav_data_format* pFormat, uint64_t totalPCMFrameCount,
-    const drwav_allocation_callbacks* pAllocationCallbacks);
+    const drlibs_allocation_callbacks* pAllocationCallbacks);
 #endif /* DR_WAV_NO_STDIO */
 
 /*
@@ -1210,13 +1203,13 @@ The buffer should contain the contents of the entire wave file, not just the
 sample data.
 */
 DRWAV_API drwav* drwav_init_memory(const void* data, size_t dataSize,
-                                   const drwav_allocation_callbacks* pAllocationCallbacks);
+                                   const drlibs_allocation_callbacks* pAllocationCallbacks);
 DRWAV_API drwav* drwav_init_memory_ex(const void* data, size_t dataSize, drwav_chunk_proc onChunk,
                                       void* pChunkUserData, uint32_t flags,
-                                      const drwav_allocation_callbacks* pAllocationCallbacks);
+                                      const drlibs_allocation_callbacks* pAllocationCallbacks);
 DRWAV_API drwav*
 drwav_init_memory_with_metadata(const void* data, size_t dataSize, uint32_t flags,
-                                const drwav_allocation_callbacks* pAllocationCallbacks);
+                                const drlibs_allocation_callbacks* pAllocationCallbacks);
 
 /*
 Helper for initializing a writer which outputs data to a memory buffer.
@@ -1229,14 +1222,14 @@ should not be considered valid until after drwav_uninit() has been called.
 */
 DRWAV_API drwav* drwav_init_memory_write(void** ppData, size_t* pDataSize,
                                          const drwav_data_format* pFormat,
-                                         const drwav_allocation_callbacks* pAllocationCallbacks);
+                                         const drlibs_allocation_callbacks* pAllocationCallbacks);
 DRWAV_API drwav*
 drwav_init_memory_write_sequential(void** ppData, size_t* pDataSize,
                                    const drwav_data_format* pFormat, uint64_t totalSampleCount,
-                                   const drwav_allocation_callbacks* pAllocationCallbacks);
+                                   const drlibs_allocation_callbacks* pAllocationCallbacks);
 DRWAV_API drwav* drwav_init_memory_write_sequential_pcm_frames(
     void** ppData, size_t* pDataSize, const drwav_data_format* pFormat, uint64_t totalPCMFrameCount,
-    const drwav_allocation_callbacks* pAllocationCallbacks);
+    const drlibs_allocation_callbacks* pAllocationCallbacks);
 
 #ifndef DR_WAV_NO_CONVERSION_API
 /*
@@ -1249,17 +1242,17 @@ DRWAV_API int16_t*
 drwav_open_and_read_pcm_frames_s16(drwav_read_proc onRead, drwav_seek_proc onSeek, void* pUserData,
                                    unsigned int* channelsOut, unsigned int* sampleRateOut,
                                    uint64_t* totalFrameCountOut,
-                                   const drwav_allocation_callbacks* pAllocationCallbacks);
+                                   const drlibs_allocation_callbacks* pAllocationCallbacks);
 DRWAV_API float*
 drwav_open_and_read_pcm_frames_f32(drwav_read_proc onRead, drwav_seek_proc onSeek, void* pUserData,
                                    unsigned int* channelsOut, unsigned int* sampleRateOut,
                                    uint64_t* totalFrameCountOut,
-                                   const drwav_allocation_callbacks* pAllocationCallbacks);
+                                   const drlibs_allocation_callbacks* pAllocationCallbacks);
 DRWAV_API int32_t*
 drwav_open_and_read_pcm_frames_s32(drwav_read_proc onRead, drwav_seek_proc onSeek, void* pUserData,
                                    unsigned int* channelsOut, unsigned int* sampleRateOut,
                                    uint64_t* totalFrameCountOut,
-                                   const drwav_allocation_callbacks* pAllocationCallbacks);
+                                   const drlibs_allocation_callbacks* pAllocationCallbacks);
 #ifndef DR_WAV_NO_STDIO
 /*
 Opens and decodes an entire wav file in a single operation.
@@ -1270,27 +1263,27 @@ drwav_free() to free the buffer.
 DRWAV_API int16_t*
 drwav_open_file_and_read_pcm_frames_s16(const char* filename, unsigned int* channelsOut,
                                         unsigned int* sampleRateOut, uint64_t* totalFrameCountOut,
-                                        const drwav_allocation_callbacks* pAllocationCallbacks);
+                                        const drlibs_allocation_callbacks* pAllocationCallbacks);
 DRWAV_API float*
 drwav_open_file_and_read_pcm_frames_f32(const char* filename, unsigned int* channelsOut,
                                         unsigned int* sampleRateOut, uint64_t* totalFrameCountOut,
-                                        const drwav_allocation_callbacks* pAllocationCallbacks);
+                                        const drlibs_allocation_callbacks* pAllocationCallbacks);
 DRWAV_API int32_t*
 drwav_open_file_and_read_pcm_frames_s32(const char* filename, unsigned int* channelsOut,
                                         unsigned int* sampleRateOut, uint64_t* totalFrameCountOut,
-                                        const drwav_allocation_callbacks* pAllocationCallbacks);
+                                        const drlibs_allocation_callbacks* pAllocationCallbacks);
 DRWAV_API int16_t*
 drwav_open_file_and_read_pcm_frames_s16_w(const wchar_t* filename, unsigned int* channelsOut,
                                           unsigned int* sampleRateOut, uint64_t* totalFrameCountOut,
-                                          const drwav_allocation_callbacks* pAllocationCallbacks);
+                                          const drlibs_allocation_callbacks* pAllocationCallbacks);
 DRWAV_API float*
 drwav_open_file_and_read_pcm_frames_f32_w(const wchar_t* filename, unsigned int* channelsOut,
                                           unsigned int* sampleRateOut, uint64_t* totalFrameCountOut,
-                                          const drwav_allocation_callbacks* pAllocationCallbacks);
+                                          const drlibs_allocation_callbacks* pAllocationCallbacks);
 DRWAV_API int32_t*
 drwav_open_file_and_read_pcm_frames_s32_w(const wchar_t* filename, unsigned int* channelsOut,
                                           unsigned int* sampleRateOut, uint64_t* totalFrameCountOut,
-                                          const drwav_allocation_callbacks* pAllocationCallbacks);
+                                          const drlibs_allocation_callbacks* pAllocationCallbacks);
 #endif
 /*
 Opens and decodes an entire wav file from a block of memory in a single
@@ -1301,17 +1294,17 @@ drwav_free() to free the buffer.
 */
 DRWAV_API int16_t* drwav_open_memory_and_read_pcm_frames_s16(
     const void* data, size_t dataSize, unsigned int* channelsOut, unsigned int* sampleRateOut,
-    uint64_t* totalFrameCountOut, const drwav_allocation_callbacks* pAllocationCallbacks);
+    uint64_t* totalFrameCountOut, const drlibs_allocation_callbacks* pAllocationCallbacks);
 DRWAV_API float* drwav_open_memory_and_read_pcm_frames_f32(
     const void* data, size_t dataSize, unsigned int* channelsOut, unsigned int* sampleRateOut,
-    uint64_t* totalFrameCountOut, const drwav_allocation_callbacks* pAllocationCallbacks);
+    uint64_t* totalFrameCountOut, const drlibs_allocation_callbacks* pAllocationCallbacks);
 DRWAV_API int32_t* drwav_open_memory_and_read_pcm_frames_s32(
     const void* data, size_t dataSize, unsigned int* channelsOut, unsigned int* sampleRateOut,
-    uint64_t* totalFrameCountOut, const drwav_allocation_callbacks* pAllocationCallbacks);
+    uint64_t* totalFrameCountOut, const drlibs_allocation_callbacks* pAllocationCallbacks);
 #endif
 
 /* Frees data that was allocated internally by dr_wav. */
-DRWAV_API void drwav_free(void* p, const drwav_allocation_callbacks* pAllocationCallbacks);
+DRWAV_API void drwav_free(void* p, const drlibs_allocation_callbacks* pAllocationCallbacks);
 
 /* Converts bytes from a wav stream to a sized type of native endian. */
 DRWAV_API uint16_t drwav_bytes_to_u16(const uint8_t* data);

--- a/src/dr_flac.c
+++ b/src/dr_flac.c
@@ -5069,7 +5069,7 @@ static void drflac__free_default(void* p, void* pUserData) {
 }
 
 static void*
-drflac__malloc_from_callbacks(size_t sz, const drflac_allocation_callbacks* pAllocationCallbacks) {
+drflac__malloc_from_callbacks(size_t sz, const drlibs_allocation_callbacks* pAllocationCallbacks) {
   if (pAllocationCallbacks == NULL) { return NULL; }
 
   if (pAllocationCallbacks->onMalloc != NULL) {
@@ -5086,7 +5086,7 @@ drflac__malloc_from_callbacks(size_t sz, const drflac_allocation_callbacks* pAll
 
 static void*
 drflac__realloc_from_callbacks(void* p, size_t szNew, size_t szOld,
-                               const drflac_allocation_callbacks* pAllocationCallbacks) {
+                               const drlibs_allocation_callbacks* pAllocationCallbacks) {
   if (pAllocationCallbacks == NULL) { return NULL; }
 
   if (pAllocationCallbacks->onRealloc != NULL) {
@@ -5112,7 +5112,7 @@ drflac__realloc_from_callbacks(void* p, size_t szNew, size_t szOld,
 }
 
 static void drflac__free_from_callbacks(void* p,
-                                        const drflac_allocation_callbacks* pAllocationCallbacks) {
+                                        const drlibs_allocation_callbacks* pAllocationCallbacks) {
   if (p == NULL || pAllocationCallbacks == NULL) { return; }
 
   if (pAllocationCallbacks->onFree != NULL) {
@@ -5123,7 +5123,7 @@ static void drflac__free_from_callbacks(void* p,
 static drflac_bool32 drflac__read_and_decode_metadata(
     drflac_read_proc onRead, drflac_seek_proc onSeek, drflac_meta_proc onMeta, void* pUserData,
     void* pUserDataMD, drflac_uint64* pFirstFramePos, drflac_uint64* pSeektablePos,
-    drflac_uint32* pSeektableSize, drflac_allocation_callbacks* pAllocationCallbacks) {
+    drflac_uint32* pSeektableSize, drlibs_allocation_callbacks* pAllocationCallbacks) {
   /*
   We want to keep track of the byte position in the stream of the seektable. At
   the time of calling this function we know that we'll be sitting on byte 42.
@@ -6533,7 +6533,7 @@ static drflac*
 drflac_open_with_metadata_private(drflac_read_proc onRead, drflac_seek_proc onSeek,
                                   drflac_meta_proc onMeta, drflac_container container,
                                   void* pUserData, void* pUserDataMD,
-                                  const drflac_allocation_callbacks* pAllocationCallbacks) {
+                                  const drlibs_allocation_callbacks* pAllocationCallbacks) {
   drflac_init_info init;
   drflac_uint32 allocationSize;
   drflac_uint32 wholeSIMDVectorCountPerChannel;
@@ -6544,7 +6544,7 @@ drflac_open_with_metadata_private(drflac_read_proc onRead, drflac_seek_proc onSe
   drflac_uint64 firstFramePos;
   drflac_uint64 seektablePos;
   drflac_uint32 seektableSize;
-  drflac_allocation_callbacks allocationCallbacks;
+  drlibs_allocation_callbacks allocationCallbacks;
   drflac* pFlac;
 
   /* CPU support first. */
@@ -7224,7 +7224,7 @@ support.
 
 static drflac_result drflac_wfopen(FILE** ppFile, const wchar_t* pFilePath,
                                    const wchar_t* pOpenMode,
-                                   const drflac_allocation_callbacks* pAllocationCallbacks) {
+                                   const drlibs_allocation_callbacks* pAllocationCallbacks) {
   if (ppFile != NULL) { *ppFile = NULL; /* Safety. */ }
 
   if (pFilePath == NULL || pOpenMode == NULL || ppFile == NULL) { return DRFLAC_INVALID_ARGS; }
@@ -7307,7 +7307,7 @@ static drflac_bool32 drflac__on_seek_stdio(void* pUserData, int offset, drflac_s
 }
 
 DRFLAC_API drflac* drflac_open_file(const char* pFileName,
-                                    const drflac_allocation_callbacks* pAllocationCallbacks) {
+                                    const drlibs_allocation_callbacks* pAllocationCallbacks) {
   drflac* pFlac;
   FILE* pFile;
 
@@ -7324,7 +7324,7 @@ DRFLAC_API drflac* drflac_open_file(const char* pFileName,
 }
 
 DRFLAC_API drflac* drflac_open_file_w(const wchar_t* pFileName,
-                                      const drflac_allocation_callbacks* pAllocationCallbacks) {
+                                      const drlibs_allocation_callbacks* pAllocationCallbacks) {
   drflac* pFlac;
   FILE* pFile;
 
@@ -7344,7 +7344,7 @@ DRFLAC_API drflac* drflac_open_file_w(const wchar_t* pFileName,
 
 DRFLAC_API drflac*
 drflac_open_file_with_metadata(const char* pFileName, drflac_meta_proc onMeta, void* pUserData,
-                               const drflac_allocation_callbacks* pAllocationCallbacks) {
+                               const drlibs_allocation_callbacks* pAllocationCallbacks) {
   drflac* pFlac;
   FILE* pFile;
 
@@ -7363,7 +7363,7 @@ drflac_open_file_with_metadata(const char* pFileName, drflac_meta_proc onMeta, v
 
 DRFLAC_API drflac*
 drflac_open_file_with_metadata_w(const wchar_t* pFileName, drflac_meta_proc onMeta, void* pUserData,
-                                 const drflac_allocation_callbacks* pAllocationCallbacks) {
+                                 const drlibs_allocation_callbacks* pAllocationCallbacks) {
   drflac* pFlac;
   FILE* pFile;
 
@@ -7428,7 +7428,7 @@ static drflac_bool32 drflac__on_seek_memory(void* pUserData, int offset,
 }
 
 DRFLAC_API drflac* drflac_open_memory(const void* pData, size_t dataSize,
-                                      const drflac_allocation_callbacks* pAllocationCallbacks) {
+                                      const drlibs_allocation_callbacks* pAllocationCallbacks) {
   drflac__memory_stream memoryStream;
   drflac* pFlac;
 
@@ -7458,7 +7458,7 @@ DRFLAC_API drflac* drflac_open_memory(const void* pData, size_t dataSize,
 DRFLAC_API drflac*
 drflac_open_memory_with_metadata(const void* pData, size_t dataSize, drflac_meta_proc onMeta,
                                  void* pUserData,
-                                 const drflac_allocation_callbacks* pAllocationCallbacks) {
+                                 const drlibs_allocation_callbacks* pAllocationCallbacks) {
   drflac__memory_stream memoryStream;
   drflac* pFlac;
 
@@ -7487,13 +7487,13 @@ drflac_open_memory_with_metadata(const void* pData, size_t dataSize, drflac_meta
 }
 
 DRFLAC_API drflac* drflac_open(drflac_read_proc onRead, drflac_seek_proc onSeek, void* pUserData,
-                               const drflac_allocation_callbacks* pAllocationCallbacks) {
+                               const drlibs_allocation_callbacks* pAllocationCallbacks) {
   return drflac_open_with_metadata_private(onRead, onSeek, NULL, drflac_container_unknown,
                                            pUserData, pUserData, pAllocationCallbacks);
 }
 DRFLAC_API drflac* drflac_open_relaxed(drflac_read_proc onRead, drflac_seek_proc onSeek,
                                        drflac_container container, void* pUserData,
-                                       const drflac_allocation_callbacks* pAllocationCallbacks) {
+                                       const drlibs_allocation_callbacks* pAllocationCallbacks) {
   return drflac_open_with_metadata_private(onRead, onSeek, NULL, container, pUserData, pUserData,
                                            pAllocationCallbacks);
 }
@@ -7501,7 +7501,7 @@ DRFLAC_API drflac* drflac_open_relaxed(drflac_read_proc onRead, drflac_seek_proc
 DRFLAC_API drflac*
 drflac_open_with_metadata(drflac_read_proc onRead, drflac_seek_proc onSeek, drflac_meta_proc onMeta,
                           void* pUserData,
-                          const drflac_allocation_callbacks* pAllocationCallbacks) {
+                          const drlibs_allocation_callbacks* pAllocationCallbacks) {
   return drflac_open_with_metadata_private(onRead, onSeek, onMeta, drflac_container_unknown,
                                            pUserData, pUserData, pAllocationCallbacks);
 }
@@ -7509,7 +7509,7 @@ DRFLAC_API drflac*
 drflac_open_with_metadata_relaxed(drflac_read_proc onRead, drflac_seek_proc onSeek,
                                   drflac_meta_proc onMeta, drflac_container container,
                                   void* pUserData,
-                                  const drflac_allocation_callbacks* pAllocationCallbacks) {
+                                  const drlibs_allocation_callbacks* pAllocationCallbacks) {
   return drflac_open_with_metadata_private(onRead, onSeek, onMeta, container, pUserData, pUserData,
                                            pAllocationCallbacks);
 }
@@ -10630,7 +10630,7 @@ DRFLAC_DEFINE_FULL_READ_AND_CLOSE(f32, float)
 DRFLAC_API drflac_int32* drflac_open_and_read_pcm_frames_s32(
     drflac_read_proc onRead, drflac_seek_proc onSeek, void* pUserData, unsigned int* channelsOut,
     unsigned int* sampleRateOut, drflac_uint64* totalPCMFrameCountOut,
-    const drflac_allocation_callbacks* pAllocationCallbacks) {
+    const drlibs_allocation_callbacks* pAllocationCallbacks) {
   drflac* pFlac;
 
   if (channelsOut) { *channelsOut = 0; }
@@ -10646,7 +10646,7 @@ DRFLAC_API drflac_int32* drflac_open_and_read_pcm_frames_s32(
 DRFLAC_API drflac_int16* drflac_open_and_read_pcm_frames_s16(
     drflac_read_proc onRead, drflac_seek_proc onSeek, void* pUserData, unsigned int* channelsOut,
     unsigned int* sampleRateOut, drflac_uint64* totalPCMFrameCountOut,
-    const drflac_allocation_callbacks* pAllocationCallbacks) {
+    const drlibs_allocation_callbacks* pAllocationCallbacks) {
   drflac* pFlac;
 
   if (channelsOut) { *channelsOut = 0; }
@@ -10662,7 +10662,7 @@ DRFLAC_API drflac_int16* drflac_open_and_read_pcm_frames_s16(
 DRFLAC_API float* drflac_open_and_read_pcm_frames_f32(
     drflac_read_proc onRead, drflac_seek_proc onSeek, void* pUserData, unsigned int* channelsOut,
     unsigned int* sampleRateOut, drflac_uint64* totalPCMFrameCountOut,
-    const drflac_allocation_callbacks* pAllocationCallbacks) {
+    const drlibs_allocation_callbacks* pAllocationCallbacks) {
   drflac* pFlac;
 
   if (channelsOut) { *channelsOut = 0; }
@@ -10678,7 +10678,7 @@ DRFLAC_API float* drflac_open_and_read_pcm_frames_f32(
 #ifndef DR_FLAC_NO_STDIO
 DRFLAC_API drflac_int32* drflac_open_file_and_read_pcm_frames_s32(
     const char* filename, unsigned int* channels, unsigned int* sampleRate,
-    drflac_uint64* totalPCMFrameCount, const drflac_allocation_callbacks* pAllocationCallbacks) {
+    drflac_uint64* totalPCMFrameCount, const drlibs_allocation_callbacks* pAllocationCallbacks) {
   drflac* pFlac;
 
   if (sampleRate) { *sampleRate = 0; }
@@ -10693,7 +10693,7 @@ DRFLAC_API drflac_int32* drflac_open_file_and_read_pcm_frames_s32(
 
 DRFLAC_API drflac_int16* drflac_open_file_and_read_pcm_frames_s16(
     const char* filename, unsigned int* channels, unsigned int* sampleRate,
-    drflac_uint64* totalPCMFrameCount, const drflac_allocation_callbacks* pAllocationCallbacks) {
+    drflac_uint64* totalPCMFrameCount, const drlibs_allocation_callbacks* pAllocationCallbacks) {
   drflac* pFlac;
 
   if (sampleRate) { *sampleRate = 0; }
@@ -10708,7 +10708,7 @@ DRFLAC_API drflac_int16* drflac_open_file_and_read_pcm_frames_s16(
 
 DRFLAC_API float* drflac_open_file_and_read_pcm_frames_f32(
     const char* filename, unsigned int* channels, unsigned int* sampleRate,
-    drflac_uint64* totalPCMFrameCount, const drflac_allocation_callbacks* pAllocationCallbacks) {
+    drflac_uint64* totalPCMFrameCount, const drlibs_allocation_callbacks* pAllocationCallbacks) {
   drflac* pFlac;
 
   if (sampleRate) { *sampleRate = 0; }
@@ -10724,7 +10724,7 @@ DRFLAC_API float* drflac_open_file_and_read_pcm_frames_f32(
 
 DRFLAC_API drflac_int32* drflac_open_memory_and_read_pcm_frames_s32(
     const void* data, size_t dataSize, unsigned int* channels, unsigned int* sampleRate,
-    drflac_uint64* totalPCMFrameCount, const drflac_allocation_callbacks* pAllocationCallbacks) {
+    drflac_uint64* totalPCMFrameCount, const drlibs_allocation_callbacks* pAllocationCallbacks) {
   drflac* pFlac;
 
   if (sampleRate) { *sampleRate = 0; }
@@ -10739,7 +10739,7 @@ DRFLAC_API drflac_int32* drflac_open_memory_and_read_pcm_frames_s32(
 
 DRFLAC_API drflac_int16* drflac_open_memory_and_read_pcm_frames_s16(
     const void* data, size_t dataSize, unsigned int* channels, unsigned int* sampleRate,
-    drflac_uint64* totalPCMFrameCount, const drflac_allocation_callbacks* pAllocationCallbacks) {
+    drflac_uint64* totalPCMFrameCount, const drlibs_allocation_callbacks* pAllocationCallbacks) {
   drflac* pFlac;
 
   if (sampleRate) { *sampleRate = 0; }
@@ -10754,7 +10754,7 @@ DRFLAC_API drflac_int16* drflac_open_memory_and_read_pcm_frames_s16(
 
 DRFLAC_API float* drflac_open_memory_and_read_pcm_frames_f32(
     const void* data, size_t dataSize, unsigned int* channels, unsigned int* sampleRate,
-    drflac_uint64* totalPCMFrameCount, const drflac_allocation_callbacks* pAllocationCallbacks) {
+    drflac_uint64* totalPCMFrameCount, const drlibs_allocation_callbacks* pAllocationCallbacks) {
   drflac* pFlac;
 
   if (sampleRate) { *sampleRate = 0; }
@@ -10767,7 +10767,7 @@ DRFLAC_API float* drflac_open_memory_and_read_pcm_frames_f32(
   return drflac__full_read_and_close_f32(pFlac, channels, sampleRate, totalPCMFrameCount);
 }
 
-DRFLAC_API void drflac_free(void* p, const drflac_allocation_callbacks* pAllocationCallbacks) {
+DRFLAC_API void drflac_free(void* p, const drlibs_allocation_callbacks* pAllocationCallbacks) {
   if (pAllocationCallbacks != NULL) {
     drflac__free_from_callbacks(p, pAllocationCallbacks);
   } else {

--- a/src/dr_mp3.c
+++ b/src/dr_mp3.c
@@ -2073,7 +2073,7 @@ static void drmp3__free_default(void* p, void* pUserData) {
 }
 
 static void* drmp3__malloc_from_callbacks(size_t sz,
-                                          const drmp3_allocation_callbacks* pAllocationCallbacks) {
+                                          const drlibs_allocation_callbacks* pAllocationCallbacks) {
   if (pAllocationCallbacks == NULL) { return NULL; }
 
   if (pAllocationCallbacks->onMalloc != NULL) {
@@ -2089,7 +2089,7 @@ static void* drmp3__malloc_from_callbacks(size_t sz,
 }
 
 static void* drmp3__realloc_from_callbacks(void* p, size_t szNew, size_t szOld,
-                                           const drmp3_allocation_callbacks* pAllocationCallbacks) {
+                                           const drlibs_allocation_callbacks* pAllocationCallbacks) {
   if (pAllocationCallbacks == NULL) { return NULL; }
 
   if (pAllocationCallbacks->onRealloc != NULL) {
@@ -2115,7 +2115,7 @@ static void* drmp3__realloc_from_callbacks(void* p, size_t szNew, size_t szOld,
 }
 
 static void drmp3__free_from_callbacks(void* p,
-                                       const drmp3_allocation_callbacks* pAllocationCallbacks) {
+                                       const drlibs_allocation_callbacks* pAllocationCallbacks) {
   if (p == NULL || pAllocationCallbacks == NULL) { return; }
 
   if (pAllocationCallbacks->onFree != NULL) {
@@ -2123,14 +2123,14 @@ static void drmp3__free_from_callbacks(void* p,
   }
 }
 
-static drmp3_allocation_callbacks drmp3_copy_allocation_callbacks_or_defaults(
-    const drmp3_allocation_callbacks* pAllocationCallbacks) {
+static drlibs_allocation_callbacks drmp3_copy_allocation_callbacks_or_defaults(
+    const drlibs_allocation_callbacks* pAllocationCallbacks) {
   if (pAllocationCallbacks != NULL) {
     /* Copy. */
     return *pAllocationCallbacks;
   } else {
     /* Defaults. */
-    drmp3_allocation_callbacks allocationCallbacks;
+    drlibs_allocation_callbacks allocationCallbacks;
     allocationCallbacks.pUserData = NULL;
     allocationCallbacks.onMalloc = drmp3__malloc_default;
     allocationCallbacks.onRealloc = drmp3__realloc_default;
@@ -2347,7 +2347,7 @@ static uint32_t drmp3_decode_next_frame(drmp3* pMP3) {
 
 static bool drmp3_init_internal(drmp3* pMP3, drmp3_read_proc onRead, drmp3_seek_proc onSeek,
                                 void* pUserData,
-                                const drmp3_allocation_callbacks* pAllocationCallbacks) {
+                                const drlibs_allocation_callbacks* pAllocationCallbacks) {
   DRMP3_ASSERT(pMP3 != NULL);
   DRMP3_ASSERT(onRead != NULL);
 
@@ -2381,7 +2381,7 @@ static bool drmp3_init_internal(drmp3* pMP3, drmp3_read_proc onRead, drmp3_seek_
 }
 
 DRMP3_API drmp3* drmp3_init(drmp3_read_proc onRead, drmp3_seek_proc onSeek, void* pUserData,
-                            const drmp3_allocation_callbacks* pAllocationCallbacks) {
+                            const drlibs_allocation_callbacks* pAllocationCallbacks) {
   if (onRead == NULL) { return NULL; }
   drmp3* pMP3 = DRMP3_MALLOC(sizeof(drmp3));
   if (pMP3 == NULL) { return NULL; }
@@ -2443,7 +2443,7 @@ static bool drmp3__on_seek_memory(void* pUserData, int byteOffset, drmp3_seek_or
 }
 
 DRMP3_API drmp3* drmp3_init_memory(const void* pData, size_t dataSize,
-                                   const drmp3_allocation_callbacks* pAllocationCallbacks) {
+                                   const drlibs_allocation_callbacks* pAllocationCallbacks) {
   if (pData == NULL || dataSize == 0) { return false; }
   drmp3* pMP3 = DRMP3_MALLOC(sizeof(drmp3));
   if (pMP3 == NULL) { return NULL; }
@@ -2926,7 +2926,7 @@ support.
 #endif
 
 static drmp3_result drmp3_wfopen(FILE** ppFile, const wchar_t* pFilePath, const wchar_t* pOpenMode,
-                                 const drmp3_allocation_callbacks* pAllocationCallbacks) {
+                                 const drlibs_allocation_callbacks* pAllocationCallbacks) {
   if (ppFile != NULL) { *ppFile = NULL; /* Safety. */ }
 
   if (pFilePath == NULL || pOpenMode == NULL || ppFile == NULL) { return DRMP3_INVALID_ARGS; }
@@ -3007,7 +3007,7 @@ static bool drmp3__on_seek_stdio(void* pUserData, int offset, drmp3_seek_origin 
 }
 
 DRMP3_API drmp3* drmp3_init_file(const char* pFilePath,
-                                 const drmp3_allocation_callbacks* pAllocationCallbacks) {
+                                 const drlibs_allocation_callbacks* pAllocationCallbacks) {
   FILE* pFile;
 
   if (drmp3_fopen(&pFile, pFilePath, "rb") != DRMP3_SUCCESS) { return NULL; }
@@ -3023,7 +3023,7 @@ DRMP3_API drmp3* drmp3_init_file(const char* pFilePath,
 }
 
 DRMP3_API drmp3* drmp3_init_file_w(const wchar_t* pFilePath,
-                                   const drmp3_allocation_callbacks* pAllocationCallbacks) {
+                                   const drlibs_allocation_callbacks* pAllocationCallbacks) {
   FILE* pFile;
 
   if (drmp3_wfopen(&pFile, pFilePath, L"rb", pAllocationCallbacks) != DRMP3_SUCCESS) {
@@ -3769,7 +3769,7 @@ static int16_t* drmp3__full_read_and_close_s16(drmp3* pMP3, drmp3_config* pConfi
 DRMP3_API float*
 drmp3_open_and_read_pcm_frames_f32(drmp3_read_proc onRead, drmp3_seek_proc onSeek, void* pUserData,
                                    drmp3_config* pConfig, uint64_t* pTotalFrameCount,
-                                   const drmp3_allocation_callbacks* pAllocationCallbacks) {
+                                   const drlibs_allocation_callbacks* pAllocationCallbacks) {
   drmp3* mp3 = drmp3_init(onRead, onSeek, pUserData, pAllocationCallbacks);
   if (mp3 == NULL) { return NULL; }
 
@@ -3779,7 +3779,7 @@ drmp3_open_and_read_pcm_frames_f32(drmp3_read_proc onRead, drmp3_seek_proc onSee
 DRMP3_API int16_t*
 drmp3_open_and_read_pcm_frames_s16(drmp3_read_proc onRead, drmp3_seek_proc onSeek, void* pUserData,
                                    drmp3_config* pConfig, uint64_t* pTotalFrameCount,
-                                   const drmp3_allocation_callbacks* pAllocationCallbacks) {
+                                   const drlibs_allocation_callbacks* pAllocationCallbacks) {
   drmp3* mp3 = drmp3_init(onRead, onSeek, pUserData, pAllocationCallbacks);
   if (mp3 == NULL) { return NULL; }
 
@@ -3789,7 +3789,7 @@ drmp3_open_and_read_pcm_frames_s16(drmp3_read_proc onRead, drmp3_seek_proc onSee
 DRMP3_API float*
 drmp3_open_memory_and_read_pcm_frames_f32(const void* pData, size_t dataSize, drmp3_config* pConfig,
                                           uint64_t* pTotalFrameCount,
-                                          const drmp3_allocation_callbacks* pAllocationCallbacks) {
+                                          const drlibs_allocation_callbacks* pAllocationCallbacks) {
   drmp3* mp3 = drmp3_init_memory(pData, dataSize, pAllocationCallbacks);
   if (mp3 == NULL) { return NULL; }
 
@@ -3799,7 +3799,7 @@ drmp3_open_memory_and_read_pcm_frames_f32(const void* pData, size_t dataSize, dr
 DRMP3_API int16_t*
 drmp3_open_memory_and_read_pcm_frames_s16(const void* pData, size_t dataSize, drmp3_config* pConfig,
                                           uint64_t* pTotalFrameCount,
-                                          const drmp3_allocation_callbacks* pAllocationCallbacks) {
+                                          const drlibs_allocation_callbacks* pAllocationCallbacks) {
   drmp3* mp3 = drmp3_init_memory(pData, dataSize, pAllocationCallbacks);
   if (mp3 == NULL) { return NULL; }
 
@@ -3810,7 +3810,7 @@ drmp3_open_memory_and_read_pcm_frames_s16(const void* pData, size_t dataSize, dr
 DRMP3_API float*
 drmp3_open_file_and_read_pcm_frames_f32(const char* filePath, drmp3_config* pConfig,
                                         uint64_t* pTotalFrameCount,
-                                        const drmp3_allocation_callbacks* pAllocationCallbacks) {
+                                        const drlibs_allocation_callbacks* pAllocationCallbacks) {
   drmp3* mp3 = drmp3_init_file(filePath, pAllocationCallbacks);
   if (mp3 == NULL) { return NULL; }
 
@@ -3820,7 +3820,7 @@ drmp3_open_file_and_read_pcm_frames_f32(const char* filePath, drmp3_config* pCon
 DRMP3_API int16_t*
 drmp3_open_file_and_read_pcm_frames_s16(const char* filePath, drmp3_config* pConfig,
                                         uint64_t* pTotalFrameCount,
-                                        const drmp3_allocation_callbacks* pAllocationCallbacks) {
+                                        const drlibs_allocation_callbacks* pAllocationCallbacks) {
   drmp3* mp3 = drmp3_init_file(filePath, pAllocationCallbacks);
   if (mp3 == NULL) { return NULL; }
 
@@ -3828,7 +3828,7 @@ drmp3_open_file_and_read_pcm_frames_s16(const char* filePath, drmp3_config* pCon
 }
 #endif
 
-DRMP3_API void* drmp3_malloc(size_t sz, const drmp3_allocation_callbacks* pAllocationCallbacks) {
+DRMP3_API void* drmp3_malloc(size_t sz, const drlibs_allocation_callbacks* pAllocationCallbacks) {
   if (pAllocationCallbacks != NULL) {
     return drmp3__malloc_from_callbacks(sz, pAllocationCallbacks);
   } else {
@@ -3836,7 +3836,7 @@ DRMP3_API void* drmp3_malloc(size_t sz, const drmp3_allocation_callbacks* pAlloc
   }
 }
 
-DRMP3_API void drmp3_free(void* p, const drmp3_allocation_callbacks* pAllocationCallbacks) {
+DRMP3_API void drmp3_free(void* p, const drlibs_allocation_callbacks* pAllocationCallbacks) {
   if (pAllocationCallbacks != NULL) {
     drmp3__free_from_callbacks(p, pAllocationCallbacks);
   } else {

--- a/src/dr_wav.c
+++ b/src/dr_wav.c
@@ -408,7 +408,7 @@ DRWAV_PRIVATE void drwav__free_default(void* p, void* pUserData) {
 }
 
 DRWAV_PRIVATE void*
-drwav__malloc_from_callbacks(size_t sz, const drwav_allocation_callbacks* pAllocationCallbacks) {
+drwav__malloc_from_callbacks(size_t sz, const drlibs_allocation_callbacks* pAllocationCallbacks) {
   if (pAllocationCallbacks == NULL) { return NULL; }
 
   if (pAllocationCallbacks->onMalloc != NULL) {
@@ -425,7 +425,7 @@ drwav__malloc_from_callbacks(size_t sz, const drwav_allocation_callbacks* pAlloc
 
 DRWAV_PRIVATE void*
 drwav__realloc_from_callbacks(void* p, size_t szNew, size_t szOld,
-                              const drwav_allocation_callbacks* pAllocationCallbacks) {
+                              const drlibs_allocation_callbacks* pAllocationCallbacks) {
   if (pAllocationCallbacks == NULL) { return NULL; }
 
   if (pAllocationCallbacks->onRealloc != NULL) {
@@ -451,7 +451,7 @@ drwav__realloc_from_callbacks(void* p, size_t szNew, size_t szOld,
 }
 
 DRWAV_PRIVATE void
-drwav__free_from_callbacks(void* p, const drwav_allocation_callbacks* pAllocationCallbacks) {
+drwav__free_from_callbacks(void* p, const drlibs_allocation_callbacks* pAllocationCallbacks) {
   if (p == NULL || pAllocationCallbacks == NULL) { return; }
 
   if (pAllocationCallbacks->onFree != NULL) {
@@ -459,14 +459,14 @@ drwav__free_from_callbacks(void* p, const drwav_allocation_callbacks* pAllocatio
   }
 }
 
-DRWAV_PRIVATE drwav_allocation_callbacks drwav_copy_allocation_callbacks_or_defaults(
-    const drwav_allocation_callbacks* pAllocationCallbacks) {
+DRWAV_PRIVATE drlibs_allocation_callbacks drwav_copy_allocation_callbacks_or_defaults(
+    const drlibs_allocation_callbacks* pAllocationCallbacks) {
   if (pAllocationCallbacks != NULL) {
     /* Copy. */
     return *pAllocationCallbacks;
   } else {
     /* Defaults. */
-    drwav_allocation_callbacks allocationCallbacks;
+    drlibs_allocation_callbacks allocationCallbacks;
     allocationCallbacks.pUserData = NULL;
     allocationCallbacks.onMalloc = drwav__malloc_default;
     allocationCallbacks.onRealloc = drwav__realloc_default;
@@ -764,7 +764,7 @@ DRWAV_PRIVATE void drwav__metadata_request_extra_memory_for_stage_2(drwav__metad
 }
 
 DRWAV_PRIVATE drwav_result drwav__metadata_alloc(drwav__metadata_parser* pParser,
-                                                 drwav_allocation_callbacks* pAllocationCallbacks) {
+                                                 drlibs_allocation_callbacks* pAllocationCallbacks) {
   if (pParser->extraCapacity != 0 || pParser->metadataCount != 0) {
     free(pParser->pData);
 
@@ -1548,7 +1548,7 @@ DRWAV_API uint16_t drwav_fmt_get_format(const drwav_fmt* pFMT) {
 
 DRWAV_PRIVATE bool drwav_preinit(drwav* pWav, drwav_read_proc onRead, drwav_seek_proc onSeek,
                                  void* pReadSeekUserData,
-                                 const drwav_allocation_callbacks* pAllocationCallbacks) {
+                                 const drlibs_allocation_callbacks* pAllocationCallbacks) {
   if (pWav == NULL || onRead == NULL || onSeek == NULL) { return false; }
 
   DRWAV_ZERO_MEMORY(pWav, sizeof(*pWav));
@@ -1990,14 +1990,14 @@ DRWAV_PRIVATE bool drwav_init__internal(drwav* pWav, drwav_chunk_proc onChunk, v
 }
 
 DRWAV_API drwav* drwav_init(drwav_read_proc onRead, drwav_seek_proc onSeek, void* pUserData,
-                            const drwav_allocation_callbacks* pAllocationCallbacks) {
+                            const drlibs_allocation_callbacks* pAllocationCallbacks) {
   return drwav_init_ex(onRead, onSeek, NULL, pUserData, NULL, 0, pAllocationCallbacks);
 }
 
 DRWAV_API drwav* drwav_init_ex(drwav_read_proc onRead, drwav_seek_proc onSeek,
                                drwav_chunk_proc onChunk, void* pReadSeekUserData,
                                void* pChunkUserData, uint32_t flags,
-                               const drwav_allocation_callbacks* pAllocationCallbacks) {
+                               const drlibs_allocation_callbacks* pAllocationCallbacks) {
   drwav* pWav = DRWAV_MALLOC(sizeof(drwav));
 
   if (!drwav_preinit(pWav, onRead, onSeek, pReadSeekUserData, pAllocationCallbacks)) {
@@ -2015,7 +2015,7 @@ DRWAV_API drwav* drwav_init_ex(drwav_read_proc onRead, drwav_seek_proc onSeek,
 
 DRWAV_API drwav* drwav_init_with_metadata(drwav_read_proc onRead, drwav_seek_proc onSeek,
                                           void* pUserData, uint32_t flags,
-                                          const drwav_allocation_callbacks* pAllocationCallbacks) {
+                                          const drlibs_allocation_callbacks* pAllocationCallbacks) {
   drwav* pWav = DRWAV_MALLOC(sizeof(drwav));
 
   if (!drwav_preinit(pWav, onRead, onSeek, pUserData, pAllocationCallbacks)) {
@@ -2596,7 +2596,7 @@ DRWAV_PRIVATE uint64_t drwav__data_chunk_size_rf64(uint64_t dataChunkSize) { ret
 DRWAV_PRIVATE bool drwav_preinit_write(drwav* pWav, const drwav_data_format* pFormat,
                                        bool isSequential, drwav_write_proc onWrite,
                                        drwav_seek_proc onSeek, void* pUserData,
-                                       const drwav_allocation_callbacks* pAllocationCallbacks) {
+                                       const drlibs_allocation_callbacks* pAllocationCallbacks) {
   if (pWav == NULL || onWrite == NULL) { return false; }
 
   if (!isSequential && onSeek == NULL) {
@@ -2765,7 +2765,7 @@ DRWAV_PRIVATE bool drwav_init_write__internal(drwav* pWav, const drwav_data_form
 
 DRWAV_API drwav* drwav_init_write(const drwav_data_format* pFormat, drwav_write_proc onWrite,
                                   drwav_seek_proc onSeek, void* pUserData,
-                                  const drwav_allocation_callbacks* pAllocationCallbacks) {
+                                  const drlibs_allocation_callbacks* pAllocationCallbacks) {
   drwav* pWav = DRWAV_MALLOC(sizeof(drwav));
   if (!drwav_preinit_write(pWav, pFormat, false, onWrite, onSeek, pUserData,
                            pAllocationCallbacks)) {
@@ -2784,7 +2784,7 @@ DRWAV_API drwav* drwav_init_write(const drwav_data_format* pFormat, drwav_write_
 DRWAV_API drwav*
 drwav_init_write_sequential(const drwav_data_format* pFormat, uint64_t totalSampleCount,
                             drwav_write_proc onWrite, void* pUserData,
-                            const drwav_allocation_callbacks* pAllocationCallbacks) {
+                            const drlibs_allocation_callbacks* pAllocationCallbacks) {
   drwav* pWav = DRWAV_MALLOC(sizeof(drwav));
 
   if (!drwav_preinit_write(pWav, pFormat, true, onWrite, NULL, pUserData, pAllocationCallbacks)) {
@@ -2802,7 +2802,7 @@ drwav_init_write_sequential(const drwav_data_format* pFormat, uint64_t totalSamp
 
 DRWAV_API drwav* drwav_init_write_sequential_pcm_frames(
     const drwav_data_format* pFormat, uint64_t totalPCMFrameCount, drwav_write_proc onWrite,
-    void* pUserData, const drwav_allocation_callbacks* pAllocationCallbacks) {
+    void* pUserData, const drlibs_allocation_callbacks* pAllocationCallbacks) {
   if (pFormat == NULL) { return NULL; }
 
   return drwav_init_write_sequential(pFormat, totalPCMFrameCount * pFormat->channels, onWrite,
@@ -2812,7 +2812,7 @@ DRWAV_API drwav* drwav_init_write_sequential_pcm_frames(
 DRWAV_API drwav*
 drwav_init_write_with_metadata(const drwav_data_format* pFormat, drwav_write_proc onWrite,
                                drwav_seek_proc onSeek, void* pUserData,
-                               const drwav_allocation_callbacks* pAllocationCallbacks,
+                               const drlibs_allocation_callbacks* pAllocationCallbacks,
                                drwav_metadata* pMetadata, uint32_t metadataCount) {
   drwav* pWav = DRWAV_MALLOC(sizeof(drwav));
   if (!drwav_preinit_write(pWav, pFormat, false, onWrite, onSeek, pUserData,
@@ -3323,7 +3323,7 @@ support.
 
 DRWAV_PRIVATE drwav_result drwav_wfopen(FILE** ppFile, const wchar_t* pFilePath,
                                         const wchar_t* pOpenMode,
-                                        const drwav_allocation_callbacks* pAllocationCallbacks) {
+                                        const drlibs_allocation_callbacks* pAllocationCallbacks) {
   if (ppFile != NULL) { *ppFile = NULL; /* Safety. */ }
 
   if (pFilePath == NULL || pOpenMode == NULL || ppFile == NULL) { return DRWAV_INVALID_ARGS; }
@@ -3409,7 +3409,7 @@ DRWAV_PRIVATE bool drwav__on_seek_stdio(void* pUserData, int offset, drwav_seek_
 }
 
 DRWAV_API drwav* drwav_init_file(const char* filename,
-                                 const drwav_allocation_callbacks* pAllocationCallbacks) {
+                                 const drlibs_allocation_callbacks* pAllocationCallbacks) {
   return drwav_init_file_ex(filename, NULL, NULL, 0, pAllocationCallbacks);
 }
 
@@ -3417,7 +3417,7 @@ DRWAV_PRIVATE bool
 drwav_init_file__internal_FILE(drwav* pWav, FILE* pFile, drwav_chunk_proc onChunk,
                                void* pChunkUserData, uint32_t flags,
                                drwav_metadata_type allowedMetadataTypes,
-                               const drwav_allocation_callbacks* pAllocationCallbacks) {
+                               const drlibs_allocation_callbacks* pAllocationCallbacks) {
   bool result;
 
   result = drwav_preinit(pWav, drwav__on_read_stdio, drwav__on_seek_stdio, (void*)pFile,
@@ -3440,7 +3440,7 @@ drwav_init_file__internal_FILE(drwav* pWav, FILE* pFile, drwav_chunk_proc onChun
 
 DRWAV_API drwav* drwav_init_file_ex(const char* filename, drwav_chunk_proc onChunk,
                                     void* pChunkUserData, uint32_t flags,
-                                    const drwav_allocation_callbacks* pAllocationCallbacks) {
+                                    const drlibs_allocation_callbacks* pAllocationCallbacks) {
   FILE* pFile;
   if (drwav_fopen(&pFile, filename, "rb") != DRWAV_SUCCESS) { return false; }
 
@@ -3456,13 +3456,13 @@ DRWAV_API drwav* drwav_init_file_ex(const char* filename, drwav_chunk_proc onChu
 }
 
 DRWAV_API drwav* drwav_init_file_w(const wchar_t* filename,
-                                   const drwav_allocation_callbacks* pAllocationCallbacks) {
+                                   const drlibs_allocation_callbacks* pAllocationCallbacks) {
   return drwav_init_file_ex_w(filename, NULL, NULL, 0, pAllocationCallbacks);
 }
 
 DRWAV_API drwav* drwav_init_file_ex_w(const wchar_t* filename, drwav_chunk_proc onChunk,
                                       void* pChunkUserData, uint32_t flags,
-                                      const drwav_allocation_callbacks* pAllocationCallbacks) {
+                                      const drlibs_allocation_callbacks* pAllocationCallbacks) {
   FILE* pFile;
   if (drwav_wfopen(&pFile, filename, L"rb", pAllocationCallbacks) != DRWAV_SUCCESS) {
     return NULL;
@@ -3482,7 +3482,7 @@ DRWAV_API drwav* drwav_init_file_ex_w(const wchar_t* filename, drwav_chunk_proc 
 
 DRWAV_API drwav*
 drwav_init_file_with_metadata(const char* filename, uint32_t flags,
-                              const drwav_allocation_callbacks* pAllocationCallbacks) {
+                              const drlibs_allocation_callbacks* pAllocationCallbacks) {
   FILE* pFile;
   if (drwav_fopen(&pFile, filename, "rb") != DRWAV_SUCCESS) { return NULL; }
 
@@ -3501,7 +3501,7 @@ drwav_init_file_with_metadata(const char* filename, uint32_t flags,
 
 DRWAV_API drwav*
 drwav_init_file_with_metadata_w(const wchar_t* filename, uint32_t flags,
-                                const drwav_allocation_callbacks* pAllocationCallbacks) {
+                                const drlibs_allocation_callbacks* pAllocationCallbacks) {
   FILE* pFile;
   if (drwav_wfopen(&pFile, filename, L"rb", pAllocationCallbacks) != DRWAV_SUCCESS) {
     return NULL;
@@ -3523,7 +3523,7 @@ drwav_init_file_with_metadata_w(const wchar_t* filename, uint32_t flags,
 DRWAV_PRIVATE bool
 drwav_init_file_write__internal_FILE(drwav* pWav, FILE* pFile, const drwav_data_format* pFormat,
                                      uint64_t totalSampleCount, bool isSequential,
-                                     const drwav_allocation_callbacks* pAllocationCallbacks) {
+                                     const drlibs_allocation_callbacks* pAllocationCallbacks) {
   bool result;
 
   result = drwav_preinit_write(pWav, pFormat, isSequential, drwav__on_write_stdio,
@@ -3545,7 +3545,7 @@ drwav_init_file_write__internal_FILE(drwav* pWav, FILE* pFile, const drwav_data_
 DRWAV_PRIVATE bool
 drwav_init_file_write__internal(drwav* pWav, const char* filename, const drwav_data_format* pFormat,
                                 uint64_t totalSampleCount, bool isSequential,
-                                const drwav_allocation_callbacks* pAllocationCallbacks) {
+                                const drlibs_allocation_callbacks* pAllocationCallbacks) {
   FILE* pFile;
   if (drwav_fopen(&pFile, filename, "wb") != DRWAV_SUCCESS) { return false; }
 
@@ -3558,7 +3558,7 @@ DRWAV_PRIVATE bool
 drwav_init_file_write_w__internal(drwav* pWav, const wchar_t* filename,
                                   const drwav_data_format* pFormat, uint64_t totalSampleCount,
                                   bool isSequential,
-                                  const drwav_allocation_callbacks* pAllocationCallbacks) {
+                                  const drlibs_allocation_callbacks* pAllocationCallbacks) {
   FILE* pFile;
   if (drwav_wfopen(&pFile, filename, L"wb", pAllocationCallbacks) != DRWAV_SUCCESS) {
     return false;
@@ -3570,7 +3570,7 @@ drwav_init_file_write_w__internal(drwav* pWav, const wchar_t* filename,
 }
 
 DRWAV_API drwav* drwav_init_file_write(const char* filename, const drwav_data_format* pFormat,
-                                       const drwav_allocation_callbacks* pAllocationCallbacks) {
+                                       const drlibs_allocation_callbacks* pAllocationCallbacks) {
   drwav* pWav = DRWAV_MALLOC(sizeof(drwav));
 
   if (!drwav_init_file_write__internal(pWav, filename, pFormat, 0, false, pAllocationCallbacks)) {
@@ -3584,7 +3584,7 @@ DRWAV_API drwav* drwav_init_file_write(const char* filename, const drwav_data_fo
 DRWAV_API drwav*
 drwav_init_file_write_sequential(const char* filename, const drwav_data_format* pFormat,
                                  uint64_t totalSampleCount,
-                                 const drwav_allocation_callbacks* pAllocationCallbacks) {
+                                 const drlibs_allocation_callbacks* pAllocationCallbacks) {
   drwav* pWav = DRWAV_MALLOC(sizeof(drwav));
 
   if (!drwav_init_file_write__internal(pWav, filename, pFormat, totalSampleCount, true,
@@ -3598,7 +3598,7 @@ drwav_init_file_write_sequential(const char* filename, const drwav_data_format* 
 
 DRWAV_API drwav* drwav_init_file_write_sequential_pcm_frames(
     const char* filename, const drwav_data_format* pFormat, uint64_t totalPCMFrameCount,
-    const drwav_allocation_callbacks* pAllocationCallbacks) {
+    const drlibs_allocation_callbacks* pAllocationCallbacks) {
   if (pFormat == NULL) { return false; }
 
   return drwav_init_file_write_sequential(filename, pFormat, totalPCMFrameCount * pFormat->channels,
@@ -3606,7 +3606,7 @@ DRWAV_API drwav* drwav_init_file_write_sequential_pcm_frames(
 }
 
 DRWAV_API drwav* drwav_init_file_write_w(const wchar_t* filename, const drwav_data_format* pFormat,
-                                         const drwav_allocation_callbacks* pAllocationCallbacks) {
+                                         const drlibs_allocation_callbacks* pAllocationCallbacks) {
   drwav* pWav = DRWAV_MALLOC(sizeof(drwav));
   if (!drwav_init_file_write_w__internal(pWav, filename, pFormat, 0, false, pAllocationCallbacks)) {
     drwav_free(pWav, pAllocationCallbacks);
@@ -3619,7 +3619,7 @@ DRWAV_API drwav* drwav_init_file_write_w(const wchar_t* filename, const drwav_da
 DRWAV_API drwav*
 drwav_init_file_write_sequential_w(const wchar_t* filename, const drwav_data_format* pFormat,
                                    uint64_t totalSampleCount,
-                                   const drwav_allocation_callbacks* pAllocationCallbacks) {
+                                   const drlibs_allocation_callbacks* pAllocationCallbacks) {
   drwav* pWav = DRWAV_MALLOC(sizeof(drwav));
   if (!drwav_init_file_write_w__internal(pWav, filename, pFormat, totalSampleCount, true,
                                          pAllocationCallbacks)) {
@@ -3632,7 +3632,7 @@ drwav_init_file_write_sequential_w(const wchar_t* filename, const drwav_data_for
 
 DRWAV_API drwav* drwav_init_file_write_sequential_pcm_frames_w(
     const wchar_t* filename, const drwav_data_format* pFormat, uint64_t totalPCMFrameCount,
-    const drwav_allocation_callbacks* pAllocationCallbacks) {
+    const drlibs_allocation_callbacks* pAllocationCallbacks) {
   if (pFormat == NULL) { return NULL; }
 
   return drwav_init_file_write_sequential_w(
@@ -3766,13 +3766,13 @@ DRWAV_PRIVATE bool drwav__on_seek_memory_write(void* pUserData, int offset,
 }
 
 DRWAV_API drwav* drwav_init_memory(const void* data, size_t dataSize,
-                                   const drwav_allocation_callbacks* pAllocationCallbacks) {
+                                   const drlibs_allocation_callbacks* pAllocationCallbacks) {
   return drwav_init_memory_ex(data, dataSize, NULL, NULL, 0, pAllocationCallbacks);
 }
 
 DRWAV_API drwav* drwav_init_memory_ex(const void* data, size_t dataSize, drwav_chunk_proc onChunk,
                                       void* pChunkUserData, uint32_t flags,
-                                      const drwav_allocation_callbacks* pAllocationCallbacks) {
+                                      const drlibs_allocation_callbacks* pAllocationCallbacks) {
   if (data == NULL || dataSize == 0) { return false; }
 
   drwav* pWav = DRWAV_MALLOC(sizeof(drwav));
@@ -3797,7 +3797,7 @@ DRWAV_API drwav* drwav_init_memory_ex(const void* data, size_t dataSize, drwav_c
 
 DRWAV_API drwav*
 drwav_init_memory_with_metadata(const void* data, size_t dataSize, uint32_t flags,
-                                const drwav_allocation_callbacks* pAllocationCallbacks) {
+                                const drlibs_allocation_callbacks* pAllocationCallbacks) {
   if (data == NULL || dataSize == 0) { return false; }
 
   drwav* pWav = DRWAV_MALLOC(sizeof(drwav));
@@ -3826,7 +3826,7 @@ DRWAV_PRIVATE bool
 drwav_init_memory_write__internal(drwav* pWav, void** ppData, size_t* pDataSize,
                                   const drwav_data_format* pFormat, uint64_t totalSampleCount,
                                   bool isSequential,
-                                  const drwav_allocation_callbacks* pAllocationCallbacks) {
+                                  const drlibs_allocation_callbacks* pAllocationCallbacks) {
   if (ppData == NULL || pDataSize == NULL) { return false; }
 
   *ppData = NULL; /* Important because we're using realloc()! */
@@ -3848,7 +3848,7 @@ drwav_init_memory_write__internal(drwav* pWav, void** ppData, size_t* pDataSize,
 
 DRWAV_API drwav* drwav_init_memory_write(void** ppData, size_t* pDataSize,
                                          const drwav_data_format* pFormat,
-                                         const drwav_allocation_callbacks* pAllocationCallbacks) {
+                                         const drlibs_allocation_callbacks* pAllocationCallbacks) {
   drwav* pWav = DRWAV_MALLOC(sizeof(drwav));
   if (!drwav_init_memory_write__internal(pWav, ppData, pDataSize, pFormat, 0, false,
                                          pAllocationCallbacks)) {
@@ -3862,7 +3862,7 @@ DRWAV_API drwav* drwav_init_memory_write(void** ppData, size_t* pDataSize,
 DRWAV_API drwav*
 drwav_init_memory_write_sequential(void** ppData, size_t* pDataSize,
                                    const drwav_data_format* pFormat, uint64_t totalSampleCount,
-                                   const drwav_allocation_callbacks* pAllocationCallbacks) {
+                                   const drlibs_allocation_callbacks* pAllocationCallbacks) {
   drwav* pWav = DRWAV_MALLOC(sizeof(drwav));
   if (!drwav_init_memory_write__internal(pWav, ppData, pDataSize, pFormat, totalSampleCount, true,
                                          pAllocationCallbacks)) {
@@ -3875,7 +3875,7 @@ drwav_init_memory_write_sequential(void** ppData, size_t* pDataSize,
 
 DRWAV_API drwav* drwav_init_memory_write_sequential_pcm_frames(
     void** ppData, size_t* pDataSize, const drwav_data_format* pFormat, uint64_t totalPCMFrameCount,
-    const drwav_allocation_callbacks* pAllocationCallbacks) {
+    const drlibs_allocation_callbacks* pAllocationCallbacks) {
   if (pFormat == NULL) { return false; }
 
   return drwav_init_memory_write_sequential(
@@ -5889,7 +5889,7 @@ DRWAV_API int16_t*
 drwav_open_and_read_pcm_frames_s16(drwav_read_proc onRead, drwav_seek_proc onSeek, void* pUserData,
                                    unsigned int* channelsOut, unsigned int* sampleRateOut,
                                    uint64_t* totalFrameCountOut,
-                                   const drwav_allocation_callbacks* pAllocationCallbacks) {
+                                   const drlibs_allocation_callbacks* pAllocationCallbacks) {
   if (channelsOut) { *channelsOut = 0; }
   if (sampleRateOut) { *sampleRateOut = 0; }
   if (totalFrameCountOut) { *totalFrameCountOut = 0; }
@@ -5909,7 +5909,7 @@ DRWAV_API float*
 drwav_open_and_read_pcm_frames_f32(drwav_read_proc onRead, drwav_seek_proc onSeek, void* pUserData,
                                    unsigned int* channelsOut, unsigned int* sampleRateOut,
                                    uint64_t* totalFrameCountOut,
-                                   const drwav_allocation_callbacks* pAllocationCallbacks) {
+                                   const drlibs_allocation_callbacks* pAllocationCallbacks) {
   if (channelsOut) { *channelsOut = 0; }
   if (sampleRateOut) { *sampleRateOut = 0; }
   if (totalFrameCountOut) { *totalFrameCountOut = 0; }
@@ -5929,7 +5929,7 @@ DRWAV_API int32_t*
 drwav_open_and_read_pcm_frames_s32(drwav_read_proc onRead, drwav_seek_proc onSeek, void* pUserData,
                                    unsigned int* channelsOut, unsigned int* sampleRateOut,
                                    uint64_t* totalFrameCountOut,
-                                   const drwav_allocation_callbacks* pAllocationCallbacks) {
+                                   const drlibs_allocation_callbacks* pAllocationCallbacks) {
 
   if (channelsOut) { *channelsOut = 0; }
   if (sampleRateOut) { *sampleRateOut = 0; }
@@ -5950,7 +5950,7 @@ drwav_open_and_read_pcm_frames_s32(drwav_read_proc onRead, drwav_seek_proc onSee
 DRWAV_API int16_t*
 drwav_open_file_and_read_pcm_frames_s16(const char* filename, unsigned int* channelsOut,
                                         unsigned int* sampleRateOut, uint64_t* totalFrameCountOut,
-                                        const drwav_allocation_callbacks* pAllocationCallbacks) {
+                                        const drlibs_allocation_callbacks* pAllocationCallbacks) {
 
   if (channelsOut) { *channelsOut = 0; }
   if (sampleRateOut) { *sampleRateOut = 0; }
@@ -5970,7 +5970,7 @@ drwav_open_file_and_read_pcm_frames_s16(const char* filename, unsigned int* chan
 DRWAV_API float*
 drwav_open_file_and_read_pcm_frames_f32(const char* filename, unsigned int* channelsOut,
                                         unsigned int* sampleRateOut, uint64_t* totalFrameCountOut,
-                                        const drwav_allocation_callbacks* pAllocationCallbacks) {
+                                        const drlibs_allocation_callbacks* pAllocationCallbacks) {
   if (channelsOut) { *channelsOut = 0; }
   if (sampleRateOut) { *sampleRateOut = 0; }
   if (totalFrameCountOut) { *totalFrameCountOut = 0; }
@@ -5989,7 +5989,7 @@ drwav_open_file_and_read_pcm_frames_f32(const char* filename, unsigned int* chan
 DRWAV_API int32_t*
 drwav_open_file_and_read_pcm_frames_s32(const char* filename, unsigned int* channelsOut,
                                         unsigned int* sampleRateOut, uint64_t* totalFrameCountOut,
-                                        const drwav_allocation_callbacks* pAllocationCallbacks) {
+                                        const drlibs_allocation_callbacks* pAllocationCallbacks) {
   if (channelsOut) { *channelsOut = 0; }
   if (sampleRateOut) { *sampleRateOut = 0; }
   if (totalFrameCountOut) { *totalFrameCountOut = 0; }
@@ -6008,7 +6008,7 @@ drwav_open_file_and_read_pcm_frames_s32(const char* filename, unsigned int* chan
 DRWAV_API int16_t*
 drwav_open_file_and_read_pcm_frames_s16_w(const wchar_t* filename, unsigned int* channelsOut,
                                           unsigned int* sampleRateOut, uint64_t* totalFrameCountOut,
-                                          const drwav_allocation_callbacks* pAllocationCallbacks) {
+                                          const drlibs_allocation_callbacks* pAllocationCallbacks) {
   if (sampleRateOut) { *sampleRateOut = 0; }
   if (channelsOut) { *channelsOut = 0; }
   if (totalFrameCountOut) { *totalFrameCountOut = 0; }
@@ -6028,7 +6028,7 @@ drwav_open_file_and_read_pcm_frames_s16_w(const wchar_t* filename, unsigned int*
 DRWAV_API float*
 drwav_open_file_and_read_pcm_frames_f32_w(const wchar_t* filename, unsigned int* channelsOut,
                                           unsigned int* sampleRateOut, uint64_t* totalFrameCountOut,
-                                          const drwav_allocation_callbacks* pAllocationCallbacks) {
+                                          const drlibs_allocation_callbacks* pAllocationCallbacks) {
   if (sampleRateOut) { *sampleRateOut = 0; }
   if (channelsOut) { *channelsOut = 0; }
   if (totalFrameCountOut) { *totalFrameCountOut = 0; }
@@ -6048,7 +6048,7 @@ drwav_open_file_and_read_pcm_frames_f32_w(const wchar_t* filename, unsigned int*
 DRWAV_API int32_t*
 drwav_open_file_and_read_pcm_frames_s32_w(const wchar_t* filename, unsigned int* channelsOut,
                                           unsigned int* sampleRateOut, uint64_t* totalFrameCountOut,
-                                          const drwav_allocation_callbacks* pAllocationCallbacks) {
+                                          const drlibs_allocation_callbacks* pAllocationCallbacks) {
   if (sampleRateOut) { *sampleRateOut = 0; }
   if (channelsOut) { *channelsOut = 0; }
   if (totalFrameCountOut) { *totalFrameCountOut = 0; }
@@ -6067,7 +6067,7 @@ drwav_open_file_and_read_pcm_frames_s32_w(const wchar_t* filename, unsigned int*
 
 DRWAV_API int16_t* drwav_open_memory_and_read_pcm_frames_s16(
     const void* data, size_t dataSize, unsigned int* channelsOut, unsigned int* sampleRateOut,
-    uint64_t* totalFrameCountOut, const drwav_allocation_callbacks* pAllocationCallbacks) {
+    uint64_t* totalFrameCountOut, const drlibs_allocation_callbacks* pAllocationCallbacks) {
   if (channelsOut) { *channelsOut = 0; }
   if (sampleRateOut) { *sampleRateOut = 0; }
   if (totalFrameCountOut) { *totalFrameCountOut = 0; }
@@ -6083,7 +6083,7 @@ DRWAV_API int16_t* drwav_open_memory_and_read_pcm_frames_s16(
 
 DRWAV_API float* drwav_open_memory_and_read_pcm_frames_f32(
     const void* data, size_t dataSize, unsigned int* channelsOut, unsigned int* sampleRateOut,
-    uint64_t* totalFrameCountOut, const drwav_allocation_callbacks* pAllocationCallbacks) {
+    uint64_t* totalFrameCountOut, const drlibs_allocation_callbacks* pAllocationCallbacks) {
   if (channelsOut) { *channelsOut = 0; }
   if (sampleRateOut) { *sampleRateOut = 0; }
   if (totalFrameCountOut) { *totalFrameCountOut = 0; }
@@ -6100,7 +6100,7 @@ DRWAV_API float* drwav_open_memory_and_read_pcm_frames_f32(
 
 DRWAV_API int32_t* drwav_open_memory_and_read_pcm_frames_s32(
     const void* data, size_t dataSize, unsigned int* channelsOut, unsigned int* sampleRateOut,
-    uint64_t* totalFrameCountOut, const drwav_allocation_callbacks* pAllocationCallbacks) {
+    uint64_t* totalFrameCountOut, const drlibs_allocation_callbacks* pAllocationCallbacks) {
   if (channelsOut) { *channelsOut = 0; }
   if (sampleRateOut) { *sampleRateOut = 0; }
   if (totalFrameCountOut) { *totalFrameCountOut = 0; }
@@ -6116,7 +6116,7 @@ DRWAV_API int32_t* drwav_open_memory_and_read_pcm_frames_s32(
 }
 #endif /* DR_WAV_NO_CONVERSION_API */
 
-DRWAV_API void drwav_free(void* p, const drwav_allocation_callbacks* pAllocationCallbacks) {
+DRWAV_API void drwav_free(void* p, const drlibs_allocation_callbacks* pAllocationCallbacks) {
   if (pAllocationCallbacks != NULL) {
     drwav__free_from_callbacks(p, pAllocationCallbacks);
   } else {


### PR DESCRIPTION
- Replaces `drX_allocation_callbacks` for a single common `drlibs_allocation_callbacks` struct